### PR TITLE
Added option to disable the keyboard in code

### DIFF
--- a/src/angular-virtual-keyboard.js
+++ b/src/angular-virtual-keyboard.js
@@ -92,6 +92,11 @@ angular.module('angular-virtual-keyboard', [])
 				return;
 			}
 
+			//Don't show virtualKeyabord if isEnabled is falsy;
+			if ($injector.has('isEnabled') && ! $injector.get('isEnabled') ) {
+				return;
+			}
+
 			// Don't show virtual keyboard in mobile devices (default)
 			if ($injector.has('UAParser')) {
 				var UAParser = $injector.get('UAParser');


### PR DESCRIPTION
I had an application\* for which I needed to disable or enable the keyboard in code.  This change allows the developer to turn off the angular-virtual-keyboard by setting a constant named isEnabled to false.

```
angular.module('angular-virtual-keyboard').constant('isEnabled',false);
```

The keyboard is still enabled by default if the constant is not present.
